### PR TITLE
accept not only by mimetype but also by extension

### DIFF
--- a/CarouselControl/index.ts
+++ b/CarouselControl/index.ts
@@ -45,6 +45,7 @@ export class CarouselControl implements ComponentFramework.StandardControl<IInpu
 	private _showSlideAnimation: boolean;
 
 	private _supportedMimeTypes: string[] = ["image/jpeg", "image/png", "image/svg+xml"];
+	private _supportedExtensions : string[] = [".jpg", ".jpeg", ".png", ".svg", ".gif"];
 
 	constructor() {
 
@@ -188,11 +189,11 @@ export class CarouselControl implements ComponentFramework.StandardControl<IInpu
 		let attachmentType = ref.typeName == "email" ? "activitymimeattachment" : "annotation";
 		let fetchXml =
 			"<fetch>" +
-			"  <entity name='" + attachmentType + "'>" +
-			"    <filter>" +
-			"      <condition attribute='objectid' operator='eq' value='" + ref.id + "'/>" +
-			"    </filter>" +
-			"  </entity>" +
+				"<entity name='" + attachmentType + "'>" +
+					"<filter>" +
+						"<condition attribute='objectid' operator='eq' value='" + ref.id + "'/>" +
+					"</filter>" +
+				"</entity>" +
 			"</fetch>";
 
 		let query = '?fetchXml=' + encodeURIComponent(fetchXml);
@@ -207,7 +208,10 @@ export class CarouselControl implements ComponentFramework.StandardControl<IInpu
 				let content = <string>record["body"] || <string>record["documentbody"];
 				let fileSize = <number>record["filesize"];
 
-				if (!this._supportedMimeTypes.includes(mimeType)) { continue; }
+				const ext = fileName.substr(fileName.lastIndexOf('.')).toLowerCase();
+				if (!this._supportedMimeTypes.includes(mimeType) && 
+					!this._supportedExtensions.includes(ext)) 
+				{ continue; }
 
 				let file = new AttachedFile(fileName, mimeType, content, fileSize);
 				items.push(file);

--- a/PCFCarouselControl.pcfproj
+++ b/PCFCarouselControl.pcfproj
@@ -1,6 +1,11 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="15.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <PowerAppsTargetsPath>$(MSBuildExtensionsPath)\Microsoft\VisualStudio\v$(VisualStudioVersion)\PowerApps</PowerAppsTargetsPath>
+  </PropertyGroup>
+
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" />
+  <Import Project="$(PowerAppsTargetsPath)\Microsoft.PowerApps.VisualStudio.Pcf.props" Condition="Exists('$(PowerAppsTargetsPath)\Microsoft.PowerApps.VisualStudio.Pcf.props')"/>
 
   <PropertyGroup>
     <Name>PCFCarouselControl</Name>
@@ -9,18 +14,32 @@
   </PropertyGroup>
 
   <PropertyGroup>
+    <TargetFrameworkVersion>v4.6.2</TargetFrameworkVersion>
+    <!--Remove TargetFramework when this is available in 16.1-->
+    <TargetFramework>net462</TargetFramework>
     <RestoreProjectStyle>PackageReference</RestoreProjectStyle>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.PowerApps.MSBuild.Pcf" Version="0.*"/>
+    <PackageReference Include="Microsoft.PowerApps.MSBuild.Pcf" Version="1.*"/>
+  </ItemGroup>
+
+ <ItemGroup>
+    <ExcludeDirectories Include="$(MSBuildThisFileDirectory)\.gitignore"/>
+    <ExcludeDirectories Include="$(MSBuildThisFileDirectory)\bin\**"/>
+    <ExcludeDirectories Include="$(MSBuildThisFileDirectory)\obj\**"/>
+    <ExcludeDirectories Include="$(OutputPath)\**"/>
+    <ExcludeDirectories Include="$(MSBuildThisFileDirectory)\*.pcfproj"/>
+    <ExcludeDirectories Include="$(MSBuildThisFileDirectory)\*.pcfproj.user"/>
+    <ExcludeDirectories Include="$(MSBuildThisFileDirectory)\*.sln"/>
+    <ExcludeDirectories Include="$(MSBuildThisFileDirectory)\node_modules\**"/>
   </ItemGroup>
 
   <ItemGroup>
-    <Content Include=".\**">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-    </Content>
+    <None Include="$(MSBuildThisFileDirectory)\**" Exclude="@(ExcludeDirectories)"/>
   </ItemGroup>
 
   <Import Project="$(MSBuildToolsPath)\Microsoft.Common.targets" />
+  <Import Project="$(PowerAppsTargetsPath)\Microsoft.PowerApps.VisualStudio.Pcf.targets" Condition="Exists('$(PowerAppsTargetsPath)\Microsoft.PowerApps.VisualStudio.Pcf.targets')"/>
+
 </Project>

--- a/package.json
+++ b/package.json
@@ -11,14 +11,14 @@
   "dependencies": {
     "@types/file-saver": "^2.0.1",
     "@types/node": "^10.12.18",
-    "@types/powerapps-component-framework": "1.1.0",
+    "@types/powerapps-component-framework": "^1.2.0",
     "bootstrap": "^4.3.1",
     "file-saver": "^2.0.2",
     "jquery": "^3.4.1",
     "popper.js": "^1.15.0"
   },
   "devDependencies": {
-    "pcf-scripts": "~0",
-    "pcf-start": "~0"
+    "pcf-scripts": "^1",
+    "pcf-start": "^1"
   }
 }


### PR DESCRIPTION
The attachments loaded using a CanvasApp have unfortunatelly the mimetype "application/octet-stream". That's a bug  in my opinion, but we have to wait until Microsoft fixes that.
Since the Carousel filters by **mimetype**, this attachments are ignored. So I've added the condition to show also by examining the **file extension**.