### PR TITLE
Issue on deactivate/activate record

### DIFF
--- a/CarouselControl/ControlManifest.Input.xml
+++ b/CarouselControl/ControlManifest.Input.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <manifest>
-  <control namespace="Fic" constructor="CarouselControl" version="1.1.1" display-name-key="Carousel Control" description-key="Carousel Control made with Bootstrap 4." control-type="standard">
+  <control namespace="Fic" constructor="CarouselControl" version="1.1.2" display-name-key="Carousel Control" description-key="Carousel Control made with Bootstrap 4." control-type="standard">
 
     <property name="dummyProperty" display-name-key="Dummy Field" description-key="Dummy Field" of-type="SingleLine.Text" usage="bound" required="true" />
     <property name="height" display-name-key="Height(px)" description-key="Height of images in pixels" of-type="Whole.None" usage="input" required="false" />

--- a/CarouselControl/ControlManifest.Input.xml
+++ b/CarouselControl/ControlManifest.Input.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <manifest>
-  <control namespace="Fic" constructor="CarouselControl" version="1.1.0" display-name-key="Carousel Control" description-key="Carousel Control made with Bootstrap 4." control-type="standard">
+  <control namespace="Fic" constructor="CarouselControl" version="1.1.1" display-name-key="Carousel Control" description-key="Carousel Control made with Bootstrap 4." control-type="standard">
 
     <property name="dummyProperty" display-name-key="Dummy Field" description-key="Dummy Field" of-type="SingleLine.Text" usage="bound" required="true" />
     <property name="height" display-name-key="Height(px)" description-key="Height of images in pixels" of-type="Whole.None" usage="input" required="false" />

--- a/CarouselControl/index.ts
+++ b/CarouselControl/index.ts
@@ -97,6 +97,8 @@ export class CarouselControl implements ComponentFramework.StandardControl<IInpu
 		carousel.appendChild(indicatorList);
 		carousel.appendChild(slides);
 		if (this._showArrows) { this.AddNavigation(); }
+		this.GetFiles(this.entityReference).then(result => this.BuildCarousel(result));
+		
 	}
 
 
@@ -104,8 +106,8 @@ export class CarouselControl implements ComponentFramework.StandardControl<IInpu
 	 * Called when any value in the property bag has changed. This includes field values, data-sets, global values such as container height and width, offline status, control metadata values such as label, visible, etc.
 	 * @param context The entire property bag available to control via Context Object; It contains values as set up by the customizer mapped to names defined in the manifest, as well as utility functions
 	 */
-	public updateView(context: ComponentFramework.Context<IInputs>): void {
-		this.GetFiles(this.entityReference).then(result => this.BuildCarousel(result));
+	public updateView(context: ComponentFramework.Context<IInputs>): void {		
+		
 	}
 
 	/** 


### PR DESCRIPTION
Each time when the record is activated/deactivated, the updateView is triggered twice, and the data will be shown twice more than before: double picture count and is rendered twice or more.
Since it's a dummy input I thought that updateView is not necessary, so I moved the GetFiles and the render in  "init". 
Is there a problem with this approach?
Best regards,
Diana
